### PR TITLE
Change nomenclature from Missing to NonValue

### DIFF
--- a/modules/pframe/src/main/scala/pellucid/pframe/Cell.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/Cell.scala
@@ -5,14 +5,18 @@ import spire.algebra.{ Eq, Order, Semigroup, Monoid }
 import spire.syntax.order._
 import spire.syntax.semigroup._
 
-/**
- * A `Cell` represents a single piece of data that may not be available or
- * meangingful in a given context. Essentially, a `Cell` is similar to
- * `Option`, except instead of `None` we have 2 different values to represent
- * missing data: `NA` (Not Available) and `NM` (Not Meaningful).
- */
+/** A [[Cell]] represents a single piece of data that may not be
+  * available or meangingful in a given context.
+  *
+  * Essentially, a [[Cell]] is similar to `Option`, except instead of
+  * `None` we have 2 representations of [[NonValue]], the absence of
+  * data: [[NA]] (Not Available) and [[NM]] (Not Meaningful).
+  *
+  * @tparam A the value type contain in the cell
+  * @see [[Value]] [[[NonValue]]] [[NA]] [[NM]]
+  */
 sealed trait Cell[+A] {
-  def isMissing: Boolean
+  def isValue: Boolean
 
   def value: Option[A]
   def valueString: String
@@ -53,22 +57,27 @@ sealed trait Cell[+A] {
 
 // TODO: there are currently issues where we get comparison between Value(NA) and NA and this should be true
 // the current tweaks to equality are just holdovers until we figure out some more details on the implementation
-// of missing values.
+// of non values.
 object Cell extends CellInstances {
   def value[A](x: A): Cell[A] = Value(x)
   def notAvailable[A]: Cell[A] = NA
   def notMeaningful[A]: Cell[A] = NM
 
-  def fromOption[A](opt: Option[A], missing: Missing = NA): Cell[A] = opt match {
+  def fromOption[A](opt: Option[A], nonValue: NonValue = NA): Cell[A] = opt match {
     case Some(a) => Value(a)
-    case None => missing
+    case None => nonValue
   }
 
   implicit def cell2Iterable[A](cell: Cell[A]): Iterable[A] = cell.value.toList
 }
 
-sealed trait Missing extends Cell[Nothing] {
-  def isMissing = true
+/** The supertype of non values, [[NA]] (''Not Available'') and
+  * [[NM]] (''Not Meaningful'')
+  *
+  * @see [[Cell]] [[NA]] [[NM]]
+  */
+sealed trait NonValue extends Cell[Nothing] {
+  def isValue = false
   def value = None
 
   override def equals(that: Any): Boolean = that match {
@@ -77,26 +86,38 @@ sealed trait Missing extends Cell[Nothing] {
   }
 }
 
-/**
- * Value is Not Available (NA). This indicates the value is simply missing.
- */
-final case object NA extends Missing { val valueString = "NA" }
 
-/**
- * Value is Not Meaningful (NM). This indicates that a values exist, but it is
- * not meaningful. For instance, if we divide by 0, then the value is not
- * meaningful, but we wouldn't necessarily say it is missing.
- */
-final case object NM extends Missing { val valueString = "NM" }
+/** A value is ''Not Available (NA)''
+  *
+  * This represents the absence of any data.
+  *
+  * @see [[Cell]] [[NonValue]] [[NM]] [[Value]]
+  */
+case object NA extends NonValue { val valueString = "NA" }
 
-/**
- * A value that exists and is meaningful.
- */
+
+/** The value is ''Not Meaningful (NM)''.
+  *
+  * This indicates that data exists, but that it is not meaningful.
+  * For instance, if we divide by 0, then the result is not
+  * meaningful, but we wouldn't necessarily say that data is
+  * unavailable.
+  *
+  * @see [[Cell]] [[NonValue]] [[NA]] [[Value]]
+  */
+case object NM extends NonValue { val valueString = "NM" }
+
+
+/** A value that is meaningful.
+  *
+  * @tparam A the type of the value contained
+  * @see [[Cell]] [[NonValue]] [[NA]] [[NM]]
+  */
 final case class Value[+A](get: A) extends Cell[A] {
   def value = Some(get)
   def valueString = get.toString
 
-  val isMissing = if (get == NA || get == NM) true else false
+  val isValue = if (get == NA || get == NM) false else true
 
   override def equals(that: Any): Boolean = that match {
     case Value(Value(NA)) => get == NA

--- a/modules/pframe/src/main/scala/pellucid/pframe/ColumnSelector.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/ColumnSelector.scala
@@ -138,8 +138,8 @@ trait ColumnSelection[Row, Col, Sz <: Size] {
     frame.withRowIndex(filteredIndex)
   }
 
-  // TODO: Grouping should take a strategy so that we can deal with missing values.
-  private def groupBy0[A: RowExtractorAux, B: Order: ClassTag](f: A => B, g: Missing => Option[B]): Frame[B, Col] = {
+  // TODO: Grouping should take a strategy so that we can deal with non values.
+  private def groupBy0[A: RowExtractorAux, B: Order: ClassTag](f: A => B, g: NonValue => Option[B]): Frame[B, Col] = {
     import spire.compat._
 
     val extractor = RowExtractor[A, Col, Sz]
@@ -150,8 +150,8 @@ trait ColumnSelection[Row, Col, Sz <: Size] {
           case Value(group0) =>
             val group = f(group0)
             groups += (group -> (row :: groups.getOrElse(group, Nil)))
-          case (missing: Missing) =>
-            g(missing) foreach { group =>
+          case (nonValue: NonValue) =>
+            g(nonValue) foreach { group =>
               groups += (group -> (row :: groups.getOrElse(group, Nil)))
             }
         }

--- a/modules/pframe/src/main/scala/pellucid/pframe/Frame.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/Frame.scala
@@ -248,7 +248,7 @@ trait Frame[Row, Col] {
       val col = cell.getOrElse(UntypedColumn.empty).cast[Any]
       val values = Series(rowIndex, col).map {
         case (_, Value(value)) => value.toString
-        case (_, missing) => missing.toString
+        case (_, nonValue) => nonValue.toString
       }.toList
       justify(header :: values)
     }.toList

--- a/modules/pframe/src/main/scala/pellucid/pframe/NumericColumnTyper.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/NumericColumnTyper.scala
@@ -61,9 +61,9 @@ object NumericColumnTyper {
 
   def convert[A, B](source: Column[A])(isValid: A => Boolean, to: A => B): Column[B] =
     new Column[B] {
-      def exists(row: Int): Boolean = source.exists(row) && isValid(source.value(row))
-      def missing(row: Int): Missing = if (source.exists(row)) NM else source.missing(row)
-      def value(row: Int): B = to(source.value(row))
+      def isValueAt(row: Int): Boolean = source.isValueAt(row) && isValid(source.valueAt(row))
+      def nonValueAt(row: Int): NonValue = if (source.isValueAt(row)) NM else source.nonValueAt(row)
+      def valueAt(row: Int): B = to(source.valueAt(row))
     }
 
   def foldValue[A](x: Any)(

--- a/modules/pframe/src/main/scala/pellucid/pframe/Series.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/Series.scala
@@ -48,13 +48,13 @@ final class Series[K,V](val index: Index[K], val column: Column[V])
    */
   def hasValues: Boolean = {
     var i = 0
-    var missing = true
-    while (i < index.size && missing) {
+    var seenValue = false
+    while (i < index.size && !seenValue) {
       val row = index.indexAt(i)
-      missing = missing & !column.exists(row)
+      seenValue = seenValue & column.isValueAt(row)
       i += 1
     }
-    !missing
+    seenValue
   }
 
   /**
@@ -71,18 +71,18 @@ final class Series[K,V](val index: Index[K], val column: Column[V])
     cfor(0)(_ < lIndices.length, _ + 1) { i =>
       val l = lIndices(i)
       val r = rIndices(i)
-      val lExists = lCol.exists(l)
-      val rExists = rCol.exists(r)
+      val lExists = lCol.isValueAt(l)
+      val rExists = rCol.isValueAt(r)
       if (lExists && rExists) {
-        bldr.addValue((lCol.value(l): VV) |+| rCol.value(r))
+        bldr.addValue((lCol.valueAt(l): VV) |+| rCol.valueAt(r))
       } else if (lExists) {
-        if (rCol.missing(r) == NM) bldr.addNM()
-        else bldr.addValue(lCol.value(l))
+        if (rCol.nonValueAt(r) == NM) bldr.addNM()
+        else bldr.addValue(lCol.valueAt(l))
       } else if (rExists) {
-        if (lCol.missing(l) == NM) bldr.addNM()
-        else bldr.addValue(rCol.value(r))
+        if (lCol.nonValueAt(l) == NM) bldr.addNM()
+        else bldr.addValue(rCol.valueAt(r))
       } else {
-        bldr.addMissing(if (lCol.missing(l) == NM) NM else rCol.missing(r))
+        bldr.addNonValue(if (lCol.nonValueAt(l) == NM) NM else rCol.nonValueAt(r))
       }
     }
 
@@ -103,16 +103,16 @@ final class Series[K,V](val index: Index[K], val column: Column[V])
     cfor(0)(_ < lIndices.length, _ + 1) { i =>
       val l = lIndices(i)
       val r = rIndices(i)
-      val lExists = lCol.exists(l)
-      val rExists = rCol.exists(r)
+      val lExists = lCol.isValueAt(l)
+      val rExists = rCol.isValueAt(r)
       if (lExists && rExists) {
-        bldr.addValue(lCol.value(l): VV)
+        bldr.addValue(lCol.valueAt(l): VV)
       } else if (lExists) {
-        bldr.addValue(lCol.value(l))
+        bldr.addValue(lCol.valueAt(l))
       } else if (rExists) {
-        bldr.addValue(rCol.value(r))
+        bldr.addValue(rCol.valueAt(r))
       } else {
-        bldr.addMissing(if (lCol.missing(l) == NM) NM else rCol.missing(r))
+        bldr.addNonValue(if (lCol.nonValueAt(l) == NM) NM else rCol.nonValueAt(r))
       }
     }
 
@@ -133,16 +133,16 @@ final class Series[K,V](val index: Index[K], val column: Column[V])
     cfor(0)(_ < lIndices.length, _ + 1) { i =>
       val l = lIndices(i)
       val r = rIndices(i)
-      val lExists = lCol.exists(l)
-      val rExists = rCol.exists(r)
+      val lExists = lCol.isValueAt(l)
+      val rExists = rCol.isValueAt(r)
       if (lExists && rExists) {
-        bldr.addValue(f(lCol.value(l), rCol.value(r)))
+        bldr.addValue(f(lCol.valueAt(l), rCol.valueAt(r)))
       } else if (lExists) {
-        bldr.addMissing(rCol.missing(r))
+        bldr.addNonValue(rCol.nonValueAt(r))
       } else if (rExists) {
-        bldr.addMissing(lCol.missing(l))
+        bldr.addNonValue(lCol.nonValueAt(l))
       } else {
-        bldr.addMissing(if (lCol.missing(l) == NM) NM else rCol.missing(r))
+        bldr.addNonValue(if (lCol.nonValueAt(l) == NM) NM else rCol.nonValueAt(r))
       }
     }
     Series(Index.ordered(keys), bldr.result())
@@ -199,8 +199,8 @@ final class Series[K,V](val index: Index[K], val column: Column[V])
     var i = 0
     while (i < index.size) {
       val row = index.indexAt(i)
-      if (column.exists(row))
-        return Some(index.keyAt(i) -> column.value(row))
+      if (column.isValueAt(row))
+        return Some(index.keyAt(i) -> column.valueAt(row))
       i += 1
     }
     None
@@ -210,8 +210,8 @@ final class Series[K,V](val index: Index[K], val column: Column[V])
     var i = index.size - 1
     while (i >= 0) {
       val row = index.indexAt(i)
-      if (column.exists(row))
-        return Some(index.keyAt(i) -> column.value(row))
+      if (column.isValueAt(row))
+        return Some(index.keyAt(i) -> column.valueAt(row))
       i -= 1
     }
     None
@@ -274,7 +274,7 @@ final class Series[K,V](val index: Index[K], val column: Column[V])
     @tailrec
     def loop(i: Int, lastValue: Int): Unit = if (i < index.size) {
       val row = index.indexAt(i)
-      if (!column.exists(row) && column.missing(row) == NA) {
+      if (!column.isValueAt(row) && column.nonValueAt(row) == NA) {
         if (K.distance(index.keyAt(i), index.keyAt(lastValue)) <= delta) {
           indices(i) = index.indexAt(lastValue)
         } else {

--- a/modules/pframe/src/main/scala/pellucid/pframe/csv/CsvRowExtractor.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/csv/CsvRowExtractor.scala
@@ -54,7 +54,7 @@ object CsvCell {
   case object Empty extends CsvCell(_.empty)
   case object Invalid extends CsvCell(_.invalid)
 
-  def fromMissing(missing: Missing): CsvCell = missing match {
+  def fromNonValue(nonValue: NonValue): CsvCell = nonValue match {
     case NA => Empty
     case NM => Invalid
   }
@@ -85,7 +85,7 @@ object CsvRow {
     def prepare[Row](frame: Frame[Row, String], cols: List[String]): Option[List[Column[CsvCell]]] =
       Some(cols map { key => frame.column[CsvCell](key)(CsvCell.CsvCellColumnTyper).column })
     def extract[Row](frame: Frame[Row, String], key: Row, row: Int, cols: List[Column[CsvCell]]): Cell[CsvRow] =
-      Value(CsvRow(cols map { _.foldRow(row)(a => a, CsvCell.fromMissing) }))
+      Value(CsvRow(cols map { _.foldRow(row)(a => a, CsvCell.fromNonValue) }))
   }
 }
 

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Count.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Count.scala
@@ -8,7 +8,7 @@ final object Count extends Reducer[Any, Int] {
 
   def reduce(column: Column[Any], indices: Array[Int], start: Int, end: Int): Value[Int] = {
     @tailrec def count(i: Int, n: Int): Int = if (i < end) {
-      val m = if (column.exists(indices(i))) n + 1 else n
+      val m = if (column.isValueAt(indices(i))) n + 1 else n
       count(i + 1, m)
     } else n
 

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Current.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Current.scala
@@ -12,8 +12,8 @@ final class Current[A] extends Reducer[(LocalDate, A), A] {
     @tailrec def loop(i: Int, latestDate: LocalDate, latestIndex: Option[Int]): Cell[A] =
       if (i < end) {
         val row = indices(i)
-        if (column.exists(row)) {
-          val (nextDate, _) = column.value(row) // TODO: NA/NM values here?
+        if (column.isValueAt(row)) {
+          val (nextDate, _) = column.valueAt(row) // TODO: NA/NM values here?
           if (nextDate.isAfter(latestDate)) loop(i + 1, nextDate, Some(row))
           else loop(i + 1, latestDate, latestIndex)
         } else

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/First.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/First.scala
@@ -9,9 +9,9 @@ final class First[A] extends Reducer[A, A] {
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int): Cell[A] = if (i < end) {
       val row = indices(i)
-      if (column.exists(row)) {
-        Value(column.value(row))
-      } else if (column.missing(row) == NA) {
+      if (column.isValueAt(row)) {
+        Value(column.valueAt(row))
+      } else if (column.nonValueAt(row) == NA) {
         loop(i + 1)
       } else {
         NM
@@ -28,9 +28,9 @@ final class Last[A] extends Reducer[A, A] {
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int): Cell[A] = if (i >= start) {
       val row = indices(i)
-      if (column.exists(row)) {
-        Value(column.value(row))
-      } else if (column.missing(row) == NA) {
+      if (column.isValueAt(row)) {
+        Value(column.valueAt(row))
+      } else if (column.nonValueAt(row) == NA) {
         loop(i - 1)
       } else {
         NM

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Max.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Max.scala
@@ -12,8 +12,8 @@ final class Max[A: Order] extends Reducer[A, A] {
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop0(i: Int): Cell[A] = if (i < end) {
       val row = indices(i)
-      if (column.exists(row)) {
-        Value(loop1(i + 1, column.value(row)))
+      if (column.isValueAt(row)) {
+        Value(loop1(i + 1, column.valueAt(row)))
       } else {
         loop0(i + 1)
       }
@@ -21,8 +21,8 @@ final class Max[A: Order] extends Reducer[A, A] {
 
     @tailrec def loop1(i: Int, max: A): A = if (i < end) {
       val row = indices(i)
-      if (column.exists(row)) {
-        val value = column.value(row)
+      if (column.isValueAt(row)) {
+        val value = column.valueAt(row)
         loop1(i + 1, if (value > max) value else max)
       } else {
         loop1(i + 1, max)

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Mean.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Mean.scala
@@ -12,8 +12,8 @@ final class Mean[A: Field] extends Reducer[A, A] {
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int, sum: A, count: Int): Cell[A] = if (i < end) {
       val row = indices(i)
-      if (column.exists(row)) {
-        loop(i + 1, sum + column.value(row), count + 1)
+      if (column.isValueAt(row)) {
+        loop(i + 1, sum + column.valueAt(row), count + 1)
       } else {
         loop(i + 1, sum, count)
       }

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/MonoidReducer.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/MonoidReducer.scala
@@ -12,9 +12,9 @@ class MonoidReducer[A: Monoid] extends Reducer[A, A] {
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int, acc: A): Cell[A] = if (i < end) {
       val row = indices(i)
-      if (column.exists(row)) {
-        loop(i + 1, acc |+| column.value(row))
-      } else if (column.missing(row) == NA) {
+      if (column.isValueAt(row)) {
+        loop(i + 1, acc |+| column.valueAt(row))
+      } else if (column.nonValueAt(row) == NA) {
         loop(i + 1, acc)
       } else {
         NM

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/SemigroupReducer.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/SemigroupReducer.scala
@@ -12,9 +12,9 @@ class SemigroupReducer[A: Semigroup] extends Reducer[A, A] {
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop0(i: Int): Cell[A] = if (i < end) {
       val row = indices(i)
-      if (column.exists(row)) {
-        loop1(i + 1, column.value(row))
-      } else if (column.missing(row) == NA) {
+      if (column.isValueAt(row)) {
+        loop1(i + 1, column.valueAt(row))
+      } else if (column.nonValueAt(row) == NA) {
         loop0(i + 1)
       } else {
         NM
@@ -23,10 +23,10 @@ class SemigroupReducer[A: Semigroup] extends Reducer[A, A] {
 
     @tailrec def loop1(i: Int, acc: A): Cell[A] = if (i < end) {
       val row = indices(i)
-      if (column.exists(row)) {
-        val value = column.value(row)
+      if (column.isValueAt(row)) {
+        val value = column.valueAt(row)
         loop1(i + 1, acc |+| value)
-      } else if (column.missing(row) == NA) {
+      } else if (column.nonValueAt(row) == NA) {
         loop1(i + 1, acc)
       } else {
         NM

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/SimpleReducer.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/SimpleReducer.scala
@@ -13,8 +13,8 @@ abstract class SimpleReducer[A: ClassTag, B] extends Reducer[A, B] {
     val bldr = ArrayBuilder.make[A]
     cfor(start)(_ < end, _ + 1) { i =>
       val row = indices(i)
-      if (column.exists(row)) {
-        bldr += column.value(row)
+      if (column.isValueAt(row)) {
+        bldr += column.valueAt(row)
       }
     }
     reduce(bldr.result())

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Unique.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Unique.scala
@@ -9,8 +9,8 @@ final class Unique[A] extends Reducer[A, Set[A]] {
     val bldr = Set.newBuilder[A]
     cfor(start)(_ < end, _ + 1) { i =>
       val row = indices(i)
-      if (column.exists(row)) {
-        bldr += column.value(row)
+      if (column.isValueAt(row)) {
+        bldr += column.valueAt(row)
       }
     }
     Value(bldr.result())

--- a/modules/pframe/src/test/scala/pellucid/pframe/ColumnSpec.scala
+++ b/modules/pframe/src/test/scala/pellucid/pframe/ColumnSpec.scala
@@ -22,10 +22,10 @@ class ColumnSpec extends Specification {
 
     "default constructor" in {
       val col = Column(row => -row)
-      col.value(0) must_== 0
-      col.value(Int.MinValue) must_== Int.MinValue
-      col.value(Int.MaxValue) must_== -Int.MaxValue
-      col.value(5) must_== -5
+      col.valueAt(0) must_== 0
+      col.valueAt(Int.MinValue) must_== Int.MinValue
+      col.valueAt(Int.MaxValue) must_== -Int.MaxValue
+      col.valueAt(5) must_== -5
     }
 
     "empty is empty" in {
@@ -37,25 +37,25 @@ class ColumnSpec extends Specification {
   "Column" should {
     val col = Column.fromCells(Vector(NM, NA, Value("a")))
 
-    "know which rows exist" in {
-      col.exists(0) must beFalse
-      col.exists(1) must beFalse
-      col.exists(2) must beTrue
-      col.exists(3) must beFalse
+    "know which rows are values" in {
+      col.isValueAt(0) must beFalse
+      col.isValueAt(1) must beFalse
+      col.isValueAt(2) must beTrue
+      col.isValueAt(3) must beFalse
     }
 
-    "return correct missing value" in {
-      col.missing(-1) must_== NA
-      col.missing(0) must_== NM
-      col.missing(1) must_== NA
-      col.missing(3) must_== NA
+    "return correct non value" in {
+      col.nonValueAt(-1) must_== NA
+      col.nonValueAt(0) must_== NM
+      col.nonValueAt(1) must_== NA
+      col.nonValueAt(3) must_== NA
     }
 
     "filter filters values to NA" in {
       val col0 = Column.fromArray(Array.range(0, 40))
       val col1 = col0 filter (_ % 2 == 0)
-      (0 until 40 by 2) map (col1 exists _) must contain(beTrue).forall
-      (1 until 40 by 2) map (col1 missing _) must contain(be_==(NA)).forall
+      (0 until 40 by 2) map (col1 isValueAt _) must contain(beTrue).forall
+      (1 until 40 by 2) map (col1 nonValueAt _) must contain(be_==(NA)).forall
     }
 
     "map should map values" in {
@@ -76,8 +76,8 @@ class ColumnSpec extends Specification {
     "mask infinite column" in {
       val col0 = Column(_.toString)
       val col1 = col0 mask (_ != 42)
-      (-5 to 41) map (col1 exists _) must contain(beTrue).forall
-      (43 to 100) map (col1 exists _) must contain(beTrue).forall
+      (-5 to 41) map (col1 isValueAt _) must contain(beTrue).forall
+      (43 to 100) map (col1 isValueAt _) must contain(beTrue).forall
       col1(42) must_== NA
     }
 
@@ -104,13 +104,13 @@ class ColumnSpec extends Specification {
     "be right biased" in {
       val a = Column(row => row)
       val b = Column(row => -row)
-      (a |+| b).value(1) must_== -1
-      (a |+| b).value(2) must_== -2
-      (b |+| a).value(1) must_== 1
-      (b |+| a).value(2) must_== 2
+      (a |+| b).valueAt(1) must_== -1
+      (a |+| b).valueAt(2) must_== -2
+      (b |+| a).valueAt(1) must_== 1
+      (b |+| a).valueAt(2) must_== 2
     }
 
-    "ignore missing values" in {
+    "ignore non values" in {
       //                                     0,        1,  2,  3,  4,  5,        6,        7
       val a = Column.fromCells(Vector(Value(1), Value(2), NA, NA, NM, NM,       NA,       NM))
       val b = Column.fromCells(Vector(      NA,       NM, NA, NM, NA, NM, Value(1), Value(2)))


### PR DESCRIPTION
- supertype of NA and NM changes from `Missing` to `NonValue`
- Cell method `isMissing` becomes `isValue`
- Column methods `exists`, `missing`, and `value`, become `isValueAt`, `nonValueAt`, and `valueAt`, respectively.
- fix all call sites
- fix up related docs and comments
