### PR TITLE
remove abstract Out type from Reducer trait

### DIFF
--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Count.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Count.scala
@@ -4,7 +4,6 @@ package reduce
 import scala.annotation.tailrec
 
 final object Count extends Reducer[Any, Int] {
-  type Out = Value[Int]
 
   def reduce(column: Column[Any], indices: Array[Int], start: Int, end: Int): Value[Int] = {
     @tailrec def count(i: Int, n: Int): Int = if (i < end) {

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Current.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Current.scala
@@ -6,7 +6,6 @@ import scala.annotation.tailrec
 import org.joda.time.LocalDate
 
 final class Current[A] extends Reducer[(LocalDate, A), A] {
-  type Out = Cell[A]
 
   def reduce(column: Column[(LocalDate, A)], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int, latestDate: LocalDate, latestIndex: Option[Int]): Cell[A] =

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/First.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/First.scala
@@ -4,7 +4,6 @@ package reduce
 import scala.annotation.tailrec
 
 final class First[A] extends Reducer[A, A] {
-  type Out = Cell[A]
 
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int): Cell[A] = if (i < end) {
@@ -23,7 +22,6 @@ final class First[A] extends Reducer[A, A] {
 }
 
 final class Last[A] extends Reducer[A, A] {
-  type Out = Cell[A]
 
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int): Cell[A] = if (i >= start) {

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Max.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Max.scala
@@ -7,7 +7,6 @@ import spire.algebra.Order
 import spire.syntax.order._
 
 final class Max[A: Order] extends Reducer[A, A] {
-  type Out = Cell[A]
 
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop0(i: Int): Cell[A] = if (i < end) {

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Mean.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Mean.scala
@@ -7,7 +7,6 @@ import spire.algebra.Field
 import spire.syntax.field._
 
 final class Mean[A: Field] extends Reducer[A, A] {
-  type Out = Cell[A]
 
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int, sum: A, count: Int): Cell[A] = if (i < end) {

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/MonoidReducer.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/MonoidReducer.scala
@@ -7,7 +7,6 @@ import spire.algebra.Monoid
 import spire.syntax.monoid._
 
 class MonoidReducer[A: Monoid] extends Reducer[A, A] {
-  type Out = Cell[A]
 
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop(i: Int, acc: A): Cell[A] = if (i < end) {

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Reducer.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Reducer.scala
@@ -7,7 +7,5 @@ package reduce
  * TODO: All reducers should return Cell[B].
  */
 trait Reducer[-A, +B] {
-  type Out <: Cell[B]
-
-  def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Out
+  def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[B]
 }

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/SemigroupReducer.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/SemigroupReducer.scala
@@ -7,7 +7,6 @@ import spire.algebra.{ Semigroup, Monoid }
 import spire.syntax.semigroup._
 
 class SemigroupReducer[A: Semigroup] extends Reducer[A, A] {
-  type Out = Cell[A]
 
   def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[A] = {
     @tailrec def loop0(i: Int): Cell[A] = if (i < end) {

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/SimpleReducer.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/SimpleReducer.scala
@@ -7,7 +7,6 @@ import scala.reflect.ClassTag
 import spire.syntax.cfor._
 
 abstract class SimpleReducer[A: ClassTag, B] extends Reducer[A, B] {
-  type Out = Cell[B]
 
   final def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Cell[B] = {
     val bldr = ArrayBuilder.make[A]

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/Unique.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/Unique.scala
@@ -4,7 +4,7 @@ package reduce
 import spire.syntax.cfor._
 
 final class Unique[A] extends Reducer[A, Set[A]] {
-  type Out = Value[Set[A]]
+
   final def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Value[Set[A]] = {
     val bldr = Set.newBuilder[A]
     cfor(start)(_ < end, _ + 1) { i =>


### PR DESCRIPTION
following discussion https://github.com/pellucidanalytics/pframe/pull/4#discussion_r12907357, @tixxit suggested simply removing the abstract type from the Reducer trait as it is unneeded.
