### PR TITLE
introduce reducers for existential and universal quantification

### DIFF
--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/package.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/package.scala
@@ -39,4 +39,72 @@ package object reduce {
   def Current[A]: Reducer[(LocalDate, A), A] = new Current[A]
 
   def Unique[A]: Reducer[A, Set[A]] = new Unique[A]
+
+
+  /** Returns a [[Reducer]] that exististentially quantifies a predicate
+    * as a reduction over a collection of [[Cell]]s.
+    *
+    * This reducer will return true upon encountering the first value
+    * that is available and meaningful ''and'' applying the predicate
+    * `p` to that value returns true. Otherwise, returns false.
+    *
+    * This reducer is unusual in that it will ignore [[NonValue]]s, in
+    * particular, it will not propogate [[NM]]. If the predicate can be
+    * satisfied by a value that is available and meaningful elsewhere in
+    * the collection, then this reduction should still return true.
+    *
+    * This reducer will only traverse the entire collection if it never
+    * encounters an available and meaningful value that satisfies the
+    * predicate `p`.
+    *
+    * @example {{{
+    * Series.empty[Int, Int].reduce(Exists[Int](i => true)) == Value(false)
+    *
+    * Series(1 -> 1, 2 -> 2).reduce(Exists[Int](i => i < 2)) == Value(true)
+    *
+    * Series.fromCells[Int, Int](1 -> NA, 2 -> 1).reduce(Exists[Int](i => i < 2)) == Value(true)
+    * Series.fromCells[Int, Int](1 -> NM, 2 -> 1).reduce(Exists[Int](i => i < 2)) == Value(true)
+    * }}}
+    *
+    * @tparam  A  the value type of the column to reduce.
+    * @param  p  the predicate to apply to the values of the column.
+    * @return a [[Reducer]] that exististentially quantifies a predicate.
+    * @see [[ForAll]]
+    */
+  def Exists[A](p: A => Boolean): Reducer[A, Boolean] = new Exists(p)
+
+
+  /** Returns a [[Reducer]] that universally quantifies a predicate
+    * as a reduction over a collection of [[Cell]]s.
+    *
+    * This reducer will return false upon encountering the first value
+    * that is not meaningful, or the first value that is available and
+    * meaningful ''and'' applying the predicate `p` to that value
+    * returns false. Otherwise, returns true.
+    *
+    * This reducer does propogate [[NM]], in a sense, but the result is
+    * `Value(false)` rather than `NM`. Unavailable values ([[NA]]) are
+    * treated as the vaccuous case, so they will in count as a counter
+    * example to the quantification.
+    *
+    * This reducer will only traverse the entire collection if it never
+    * encounters a not meaningful value or a meaningful value that does
+    * not satisfy the predicate `p`.
+    *
+    * @example {{{
+    * Series.empty[Int, Int].reduce(ForAll[Int](i => false)) == Value(true)
+    *
+    * Series(1 -> 1, 2 -> 2).reduce(ForAll[Int](i => i < 3)) == Value(true)
+    * Series(1 -> 1, 2 -> 2).reduce(ForAll[Int](i => i < 2)) == Value(false)
+    *
+    * Series.fromCells[Int, Int](1 -> NA)        .reduce(ForAll[Int](i => false)) == Value(true)
+    * Series.fromCells[Int, Int](1 -> 1, 2 -> NM).reduce(ForAll[Int](i => i < 2)) == Value(false)
+    * }}}
+    *
+    * @tparam  A  the value type of the column to reduce.
+    * @param  p  the predicate to apply to the values of the column.
+    * @return a [[Reducer]] that universally quantifies a predicate.
+    * @see [[Exists]]
+    */
+  def ForAll[A](p: A => Boolean): Reducer[A, Boolean] = new ForAll(p)
 }

--- a/modules/pframe/src/main/scala/pellucid/pframe/reduce/predicates.scala
+++ b/modules/pframe/src/main/scala/pellucid/pframe/reduce/predicates.scala
@@ -1,0 +1,108 @@
+package pellucid.pframe
+package reduce
+
+import scala.annotation.tailrec
+
+
+/** A [[Reducer]] that exististentially quantifies a predicate
+  * as a reduction over a collection of [[Cell]]s.
+  *
+  * This reducer will return true upon encountering the first value
+  * that is available and meaningful ''and'' applying the predicate
+  * `p` to that value returns true. Otherwise, returns false.
+  *
+  * This reducer is unusual in that it will ignore [[NonValue]]s, in
+  * particular, it will not propogate [[NM]]. If the predicate can be
+  * satisfied by a value that is available and meaningful elsewhere in
+  * the collection, then this reduction should still return true.
+  *
+  * This reducer will only traverse the entire collection if it never
+  * encounters an available and meaningful value that satisfies the
+  * predicate `p`.
+  *
+  * @example {{{
+  * Series.empty[Int, Int].reduce(new Exists[Int](i => true)) == Value(false)
+  *
+  * Series(1 -> 1, 2 -> 2).reduce(new Exists[Int](i => i < 2)) == Value(true)
+  *
+  * Series.fromCells[Int, Int](1 -> NA, 2 -> 1).reduce(new Exists[Int](i => i < 2)) == Value(true)
+  * Series.fromCells[Int, Int](1 -> NM, 2 -> 1).reduce(new Exists[Int](i => i < 2)) == Value(true)
+  * }}}
+  *
+  * @note This reducer will always return precisely `Value[Boolean]`,
+  *   rather than `Cell[Boolean]`. This in constrast to most reducers
+  *   that will also return [[NonValue]]s.
+  *
+  * @tparam  A  the value type of the column to reduce.
+  *
+  * @constructor Create a existential quantifier reducer from a predicate `p`.
+  * @param  p  the predicate to apply to the values of the column.
+  * @see [[ForAll]]
+  */
+final class Exists[A](p: A => Boolean) extends Reducer[A, Boolean] {
+
+  def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Value[Boolean] = {
+    @tailrec def loop(i: Int): Value[Boolean] = if (i < end) {
+      val row = indices(i)
+      if (column.isValueAt(row)) {
+        if (p(column.valueAt(row))) Value(true) else loop(i + 1)
+      } else loop(i + 1)
+    } else Value(false)
+
+    loop(start)
+  }
+}
+
+
+/** A [[Reducer]] that universally quantifies a predicate
+  * as a reduction over a collection of [[Cell]]s.
+  *
+  * This reducer will return false upon encountering the first value
+  * that is not meaningful, or the first value that is available and
+  * meaningful ''and'' applying the predicate `p` to that value
+  * returns false. Otherwise, returns true.
+  *
+  * This reducer does propogate [[NM]], in a sense, but the result is
+  * `Value(false)` rather than `NM`. Unavailable values ([[NA]]) are
+  * treated as the vaccuous case, so they will in count as a counter
+  * example to the quantification.
+  *
+  * This reducer will only traverse the entire collection if it never
+  * encounters a not meaningful value or a meaningful value that does
+  * not satisfy the predicate `p`.
+  *
+  * @example {{{
+  * Series.empty[Int, Int].reduce(new ForAll[Int](i => false)) == Value(true)
+  *
+  * Series(1 -> 1, 2 -> 2).reduce(new ForAll[Int](i => i < 3)) == Value(true)
+  * Series(1 -> 1, 2 -> 2).reduce(new ForAll[Int](i => i < 2)) == Value(false)
+  *
+  * Series.fromCells[Int, Int](1 -> NA)        .reduce(new ForAll[Int](i => false)) == Value(true)
+  * Series.fromCells[Int, Int](1 -> 1, 2 -> NM).reduce(new ForAll[Int](i => i < 2)) == Value(false)
+  * }}}
+  *
+  * @note This reducer will always return precisely `Value[Boolean]`,
+  *   rather than `Cell[Boolean]`. This in constrast to most reducers
+  *   that will also return [[NonValue]]s.
+  *
+  * @tparam  A  the value type of the column to reduce.
+  *
+  * @constructor Create a universal quantifier reducer from a predicate `p`.
+  * @param  p  the predicate to apply to the values of the column.
+  * @see [[Exists]]
+  */
+final class ForAll[A](p: A => Boolean) extends Reducer[A, Boolean] {
+
+  def reduce(column: Column[A], indices: Array[Int], start: Int, end: Int): Value[Boolean] = {
+    @tailrec def loop(i: Int): Value[Boolean] = if (i < end) {
+      val row = indices(i)
+      if (column.isValueAt(row)) {
+        if (p(column.valueAt(row))) loop(i + 1) else Value(false)
+      } else if (column.nonValueAt(row) == NA) {
+        loop(i + 1)
+      } else Value(false)
+    } else Value(true)
+
+    loop(start)
+  }
+}


### PR DESCRIPTION
add two new reducers that reduce either an existentially or universally quantified predicate over the values. Their behavior with respect to non values is a little nuanced: existential quantification can skip over non values, while universal quantification should interpret NM as false.
