### PR TITLE
Add Frame.fill constructor.

### DIFF
--- a/modules/framian/src/main/scala/framian/Frame.scala
+++ b/modules/framian/src/main/scala/framian/Frame.scala
@@ -405,6 +405,15 @@ object Frame {
     ColOrientedFrame(rowIndex, Index(colKeys.toArray), Column.fromArray(cols.toArray))
   }
 
+  def fill[A: Order: ClassTag, B: Order: ClassTag, C: ClassTag](rows: Iterable[A], cols: Iterable[B])(f: (A, B) => Cell[C]): Frame[A, B] = {
+    val rows0 = rows.toVector
+    val cols0 = cols.toVector
+    val columns = Column.fromArray(cols0.map { b =>
+      TypedColumn(Column.fromCells(rows0.map { a => f(a, b) })): UntypedColumn
+    }.toArray)
+    fromColumns(Index.fromKeys(rows0: _*), Index.fromKeys(cols0: _*), columns)
+  }
+
   def fromRows[A, Col: ClassTag](rows: A*)(implicit pop: RowPopulator[A, Int, Col]): Frame[Int, Col] =
     pop.frame(rows.zipWithIndex.foldLeft(pop.init) { case (state, (data, row)) =>
       pop.populate(state, row, data)

--- a/modules/framian/src/test/scala/framian/FrameSpec.scala
+++ b/modules/framian/src/test/scala/framian/FrameSpec.scala
@@ -66,6 +66,18 @@ class FrameSpec extends Specification {
     .withRowIndex(Index.fromKeys("Bob", "Alice", "Charlie"))
 
   "Frame" should {
+    "be fill-able" in {
+      val f = Frame.fill(1 to 3, 4 to 5) { (i, j) =>
+        val k = i + j
+        if (k % 2 == 0) NA else Value(k)
+      }
+
+      f must_== Frame.fromSeries(
+        4 -> Series.fromCells(1 -> Value(5), 2 ->       NA, 3 -> Value(7)),
+        5 -> Series.fromCells(1 ->       NA, 2 -> Value(7), 3 ->       NA)
+      )
+    }
+
     "have sane equality" in {
       f0 must_== f0
       f0 must_!= f1


### PR DESCRIPTION
This adds a new method to allow for construction of frames based solely on their rows/cols. For instance, `Frame.fill(rows, cols) { (row, col) => ... }`.
