### PR TITLE
remove implicit conversion of Cell to Iterable

### DIFF
--- a/framian/src/main/scala/framian/Cell.scala
+++ b/framian/src/main/scala/framian/Cell.scala
@@ -254,8 +254,6 @@ object Cell extends CellInstances {
     case Some(a) => Value(a)
     case None => nonValue
   }
-
-  implicit def cell2Iterable[A](cell: Cell[A]): Iterable[A] = cell.toList
 }
 
 /** The supertype of non values, [[NA]] (''Not Available'') and


### PR DESCRIPTION
pollutes method space, and is surplus to requirement as the relevant methods have been implemented explicitly
