### PR TITLE
Fix bug in ConcatColumn#reindex.

### DIFF
--- a/framian/src/main/scala/framian/UntypedColumn.scala
+++ b/framian/src/main/scala/framian/UntypedColumn.scala
@@ -87,9 +87,9 @@ case class ConcatColumn(col0: UntypedColumn, col1: UntypedColumn, offset: Int) e
       if (row < offset) row else offset
     }
     val index1 = index.map { row =>
-      if (row < offset) offset - 1 else row
+      if (row < offset) -1 else row - offset
     }
-    MergedUntypedColumn(col0.setNA(offset).reindex(index0), col1.setNA(offset - 1).reindex(index1))
+    MergedUntypedColumn(col0.setNA(offset).reindex(index0), col1.setNA(-1).reindex(index1))
   }
   def setNA(row: Int): UntypedColumn =
     if (row < offset) ConcatColumn(col0.setNA(row), col1, offset)

--- a/framian/src/test/scala/framian/UntypedColumnSpec.scala
+++ b/framian/src/test/scala/framian/UntypedColumnSpec.scala
@@ -1,0 +1,15 @@
+package framian
+
+import org.specs2.mutable.Specification
+
+class UntypedColumnSpec extends Specification {
+  "ConcatColumn" should {
+    "be stable after reindex" in {
+      val col1 = TypedColumn(Column.fromArray(Array(1, 2)))
+      val col2 = TypedColumn(Column.fromArray(Array(3, 4)))
+      val col3 = ConcatColumn(col1, col2, 2)
+      val col = col3.reindex(Array(0,1,2,3)).cast[Int]
+      (0 to 4).map(col(_)) must_== Seq(Value(1), Value(2), Value(3), Value(4), NA)
+    }
+  }
+}


### PR DESCRIPTION
If a `ConcatColumn` was reindexed, it would result in the 2nd half of the column being filled with `NA`s.
