### PR TITLE
map macros module into main module for publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,13 @@ lazy val framianMacros = project.
 lazy val framian = project.
   in(file("framian")).
   enablePlugins(BenchmarkPlugin).
-  dependsOn(framianMacros)
+  dependsOn(framianMacros).
+  settings(
+    // map framian-macros project classes and sources into framian
+    mappings in (Compile, packageBin) <++= mappings in (framianMacros, Compile, packageBin),
+    mappings in (Compile, packageSrc) <++= mappings in (framianMacros, Compile, packageSrc)
+  )
+
 
 lazy val framianJsonBase = project.
   in(file("framian-json-base")).

--- a/framian-macros/build.sbt
+++ b/framian-macros/build.sbt
@@ -1,25 +1,10 @@
 
-name := "framian-column"
+name := "framian-macros"
 
-libraryDependencies ++= {
-  import Dependencies._
-  Seq(
-    Compile.spire,
-    Test.discipline,
-    Test.specs2,
-    Test.scalaCheck
-  )
-}
-
-initialCommands := """
-  |import framian._
-""".stripMargin('|')
-
-
-testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "junitxml", "console")
-
-TestCoverage.settings
-
-Publish.settings
+libraryDependencies += Dependencies.Compile.spire
 
 Dependencies.macroParadise
+
+publish := ()
+
+publishLocal := ()


### PR DESCRIPTION
avoid publishing a jar just for the macros impl, and instead map the sources and classes into the core framian project at package-time
