### PR TITLE
Upgrade dependencies

### DIFF
--- a/framian/src/main/scala/framian/NumericColumnTyper.scala
+++ b/framian/src/main/scala/framian/NumericColumnTyper.scala
@@ -21,6 +21,8 @@
 
 package framian
 
+import java.math.MathContext
+
 import scala.math.ScalaNumericAnyConversions
 import scala.reflect.{ ClassTag, classTag }
 import scala.{ specialized => spec }
@@ -241,7 +243,7 @@ private[framian] final class BigIntTyper extends NumericColumnTyper[BigInt] {
       n => if (n.isWhole) Some(BigDecimal(n).toBigInt) else None,
       n => Some(n),
       n => if (n.isWhole) Some(n.toBigInt) else None,
-      n => if (n.isWhole) Some(n.numerator) else None,
+      n => if (n.isWhole) Some(n.numerator.toBigInt) else None,
       n => Try(BigInt(n)).toOption,
       None
     )
@@ -265,7 +267,7 @@ private[framian] final class BigDecimalTyper extends NumericColumnTyper[BigDecim
       n => Some(BigDecimal(n)),
       n => Some(BigDecimal(n)),
       n => Some(n),
-      n => Try(n.toBigDecimal).toOption,
+      n => Try(n.toBigDecimal(MathContext.DECIMAL64)).toOption,
       n => Try(BigDecimal(n)).toOption,
       None
     )

--- a/framian/src/main/scala/framian/column/EvalColumn.scala
+++ b/framian/src/main/scala/framian/column/EvalColumn.scala
@@ -61,7 +61,7 @@ private[framian] case class EvalColumn[A](f: Int => Cell[A]) extends BoxedColumn
 
   def shift(n: Int): Column[A] = EvalColumn { row =>
     try {
-      f(Checked.minus(row, n))
+      f(Checked.checked(row - n))
     } catch { case (_: ArithmeticOverflowException) =>
       // If we overflow, then it means that `row - n` overflowed and, hence,
       // wrapped around. Since `shift` is meant to just shift rows, and not

--- a/framian/src/test/scala/framian/Generators.scala
+++ b/framian/src/test/scala/framian/Generators.scala
@@ -118,7 +118,7 @@ trait FrameGenerators {
 
   def genFrameWithCol[R: Order: ClassTag, C, A: ClassTag](genFrame: Gen[Frame[R, C]], col: C, genCell: Gen[Cell[A]]): Gen[Frame[R, C]] = {
     genFrame.flatMap { frame =>
-      val seriesGen: Gen[Series[R, A]] = Gen.sequence[Vector, (R, Cell[A])](frame.rowIndex.map { case (key, _) =>
+      val seriesGen: Gen[Series[R, A]] = Gen.sequence[Vector[(R, Cell[A])], (R, Cell[A])](frame.rowIndex.map { case (key, _) =>
         genCell.map(key -> _)
       }).map(Series.fromCells(_))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,13 +3,13 @@ import sbt._
 object Dependencies {
 
   object V {
-    val Spire              = "0.8.2"
+    val Spire              = "0.11.0"
     val Shapeless          = "2.3.0"
-    val Discipline         = "0.2.1"
+    val Discipline         = "0.4"
 
     // Test libraries
     val ScalaTest          = "2.2.6"
-    val ScalaCheck         = "1.11.6"
+    val ScalaCheck         = "1.12.5"
   }
 
   // Compile
@@ -22,7 +22,7 @@ object Dependencies {
   object Test {
     val scalaTest       =   "org.scalatest"         %% "scalatest"                   % V.ScalaTest     % "test"
     val scalaCheck      =   "org.scalacheck"        %% "scalacheck"                  % V.ScalaCheck    % "test"
-    val spireLaws       =   "org.spire-math"        %% "spire-scalacheck-binding"    % V.Spire         % "test"
+    val spireLaws       =   "org.spire-math"        %% "spire-laws"                  % V.Spire         % "test"
     val discipline      =   "org.typelevel"         %% "discipline"                  % V.Discipline    % "test"
   }
 }


### PR DESCRIPTION
This PR is meant to be a follow-on to #69. ~~but I'm not entirely sure how to properly PR back into `master` a branch of a branch ([`upgrade-deps`](https://github.com/tixxit/framian/tree/upgrade-deps) is a branch off of [`scalatest`](https://github.com/tixxit/framian/tree/scalatest)) so this PR might have quite a bit more noise until you merge #69. Alternatively, only look at https://github.com/tixxit/framian/commit/28572a4fff19c9f91343a65a5f9741699f00313a.~~

Key points:
* Upgrades spire, ScalaCheck, spire-laws, and Discipline.
* Fixes compile errors due to upgrade from spire 0.8.2 => 0.11.0
* There is one case where `Rational` => `BigDecimal` now needs a `java.math.MathContext` to properly round off the end, so at first I went with the big but not unbounded `MathContext.DECIMAL128`, but one of the tests failed with:

```scala
[info] - cast Rational to BigDecimal *** FAILED ***
[info]   Vector(Value(0.3333333333333333333333333333333333), Value(0.9991902834008097165991902834008097)) did not equal ArrayBuffer(Value(0.3333333333333333), Value(0.9991902834008097)) (NumericColumnTyperSpec.scala:30)
```

Changing that `Rational` => `BigDecimal` cast to use `MathContext.DECIMAL64` seems to fix to test case though I did want to bring it to attention that while _~it works like before~_, I don't know if that is intended.